### PR TITLE
feat: add call stack tracing to code visualizer

### DIFF
--- a/api/utils/pythonTracer.py
+++ b/api/utils/pythonTracer.py
@@ -6,11 +6,21 @@ import runpy
 traces = []
 
 
+def build_stack(frame):
+    stack = []
+    while frame:
+        stack.append(frame.f_code.co_name)
+        frame = frame.f_back
+    return list(reversed(stack))
+
+
 def tracefunc(frame, event, arg):
-    if event == 'line':
+    if event in ('line', 'call', 'return'):
         traces.append({
-            'event': 'step',
+            'event': event,
             'line': frame.f_lineno,
+            'func': frame.f_code.co_name,
+            'stack': build_stack(frame),
             'locals': {k: repr(v) for k, v in frame.f_locals.items()},
         })
     return tracefunc


### PR DESCRIPTION
## Summary
- track line, call, and return events with call stack for Python execution
- visualize call/return events and show call stack in the code visualizer

## Testing
- `npm test` *(fails: jest couldn't parse ES modules and jsdom environment missing)*

------
https://chatgpt.com/codex/tasks/task_b_68b9578ee6e483239281dff72e007afa